### PR TITLE
Removes package engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,6 @@
   "description": "GUI for DynamoDB. Useful for local development.",
   "main": "index.js",
   "bin": "./bin/dynamodb-admin.js",
-  "engines": {
-    "node": "6.4.0",
-    "npm": "3.10.3"
-  },
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
This PR removes the package engines to minimize incompatible engine errors.

At my work (and in personal projects) our environments all run different node/npm versions (both current and LTS) so dynamodb-admin doesn't install smoothly because of the engines set in the package.json. Because of this we have the bad practice of using the `--ignore-engines` flag.