### PR TITLE
Moved bower dependency from dev to regular dependency section

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "es7-object-polyfill": "0.0.1",
     "express": "^4.14.0",
     "js-yaml": "^3.6.1",
+    "bower": "^1.8.0",
     "lodash": "^4.16.4"
   },
   "devDependencies": {
-    "bower": "^1.8.0",
     "jest-cli": "^15.0.2"
   }
 }


### PR DESCRIPTION
PR #12 introduced bower dependency, but it was added as a dev dependency, so when we installed this package with `npm i dynamodb-admin`, it was unable to run the bower command.
I could reproduce the error, and moving from dev to regular dependency fixed it.

Thanks @msaglietto for pointing this.

@aaronshaf This PR is kinda important because installation from `npm` is crashing for those who don't have `bower` command available

Closes #13 