### PR TITLE
Fix keys not shown when don't exist on first item (fixes #24)

### DIFF
--- a/__tests__/extractKeysForItems.js
+++ b/__tests__/extractKeysForItems.js
@@ -1,0 +1,29 @@
+const { extractKeysForItems } = require('../util')
+
+describe('extractKeysForItems', () => {
+  it('extract keys from multiple items', () => {
+    const parsedKey = extractKeysForItems(items)
+    expect(parsedKey).toEqual([
+      'attribute1',
+      'attribute2',
+      'attribute3',
+      'attribute4',
+    ])
+  })
+})
+
+const items = [
+  {
+    'attribute1': 'value',
+    'attribute2': 'value',
+  },
+  {
+    'attribute1': 'value',
+    'attribute2': 'value',
+    'attribute3': 'value',
+  },
+  {
+    'attribute3': 'value',
+    'attribute4': 'value',
+  },
+];

--- a/util.js
+++ b/util.js
@@ -20,6 +20,18 @@ exports.parseKey = function(keys, table) {
   }, {})
 }
 
+exports.extractKeysForItems = function(Items) {
+  const keys = new Set();
+  for (const item of Items) {
+    for (const key of Object.keys(item)) {
+      if (!keys.has(key)) {
+        keys.add(key);
+      }
+    }
+  }
+  return Array.from(keys);
+}
+
 function typecastKey(keyName, keyValue, table) {
   const definition = table.AttributeDefinitions.find(attribute => {
     return attribute.AttributeName === keyName

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -146,7 +146,6 @@
     }
     </script>
 
-    <% const keys = Items[0] !== undefined ? Object.keys(Items[0]): [] %>
     <% const primaryKeys = Items[0] !== undefined ? Object.keys(Items[0].__key): [] %>
     <% const ignored = ['__key'].concat(primaryKeys) %>
     <table class="table">
@@ -156,9 +155,9 @@
           <% for(let i = 0; i < primaryKeys.length; i++) { %>
             <td><%= primaryKeys[i] %></td>
           <% } %>
-          <% for(let i = 0; i < keys.length; i++) { %>
-              <% if (!ignored.includes(keys[i])) { %>
-                <td><%= keys[i] %></td>
+          <% for(const key of UniqueKeys) { %>
+              <% if (!ignored.includes(key)) { %>
+                <td><%= key %></td>
               <% } %>
           <% } %>
       </tr>
@@ -172,9 +171,9 @@
           <% for(let i = 0; i < primaryKeys.length; i++) { %>
             <td><%= Items[row][primaryKeys[i]] %></td>
           <% } %>
-          <% for(let column = 0; column < keys.length; column++) { %>
-              <% if (!ignored.includes(keys[column])) { %>
-                <td><%= Items[row][keys[column]] %></td>
+          <% for(let column = 0; column < UniqueKeys.length; column++) { %>
+              <% if (!ignored.includes(UniqueKeys[column])) { %>
+                <td><%= Items[row][UniqueKeys[column]] %></td>
               <% } %>
           <% } %>
       </tr>


### PR DESCRIPTION
Getting keys from all the items, not only first, as first might
not have keys that later items have.