### PR TITLE
Don't listen on broadcast address and log server address on starting

### DIFF
--- a/index.js
+++ b/index.js
@@ -511,6 +511,8 @@ app.put(
 )
 
 const port = process.env.PORT || 8001
-app.listen(port, () => {
-  console.log(`  listening on port ${port}`)
+const server = app.listen(port, '127.0.0.1');
+server.on('listening', () => {
+  const address = server.address();
+  console.log(`  listening on http://${address.address}:${address.port}`);
 })


### PR DESCRIPTION
 - Starting server explicitly on host 127.0.0.1 instead of default 0.0.0.0.
 - Logging server address to make it easier to open the gui after starting server.