### PR TITLE
Fix invalid properties for default value of argument

### DIFF
--- a/bin/dynamodb-admin.js
+++ b/bin/dynamodb-admin.js
@@ -23,7 +23,7 @@ parser.addArgument(['-o', '--open'], {
 
 parser.addArgument(['-p', '--port'], {
   type: 'int',
-  default: 8001,
+  defaultValue: 8001,
   help: 'Port to run on (default: 8001)',
 })
 


### PR DESCRIPTION
https://github.com/nodeca/argparse/blob/master/README.md says:
`Use defaultValue instead of default.`