### PR TITLE
Added delete table confirmation + fix page refresh

### DIFF
--- a/views/tables.ejs
+++ b/views/tables.ejs
@@ -32,15 +32,23 @@
     })
 
     function deleteTable (TableName) {
+      let answer = confirm(`Are you sure you want to delete table "${TableName}" ?`)
+
+      if(!answer){
+        return
+      }
+
       fetch(`/tables/${TableName}`, {
         method: 'delete'
-      }).then((response) => {
+      })
+      .then((response) => {
         if (!response.ok) {
           throw new Error
         }
         window.location.href = '/'
-      }).catch(() => {
-        window.alert('There was an error when attempting to delete the table.')
+      })
+      .catch((err) => {
+        window.alert('There was an error when attempting to delete the table. ', err)
       })
     }
     </script>
@@ -56,7 +64,7 @@
           <a href='/tables/<%= data[i].TableName %>'>
             <%= data[i].TableName %>
           </a>
-          <a href="/" onClick="deleteTable('<%= data[i].TableName %>')"
+          <a href="/" onClick="deleteTable('<%= data[i].TableName %>'); return false"
               class="badge badge-danger badge-pill float-right ml-1">
             Delete
           </a>

--- a/views/tables.ejs
+++ b/views/tables.ejs
@@ -32,9 +32,7 @@
     })
 
     function deleteTable (TableName) {
-      let answer = confirm(`Are you sure you want to delete table "${TableName}" ?`)
-
-      if(!answer){
+      if(!confirm(`Are you sure you want to delete table "${TableName}" ?`)){
         return
       }
 
@@ -48,7 +46,7 @@
         window.location.href = '/'
       })
       .catch((err) => {
-        window.alert('There was an error when attempting to delete the table. ', err)
+        window.alert(`There was an error when attempting to delete the table:\n\n${err}`)
       })
     }
     </script>
@@ -64,7 +62,7 @@
           <a href='/tables/<%= data[i].TableName %>'>
             <%= data[i].TableName %>
           </a>
-          <a href="/" onClick="deleteTable('<%= data[i].TableName %>'); return false"
+          <a href="#" onClick="deleteTable('<%= data[i].TableName %>')"
               class="badge badge-danger badge-pill float-right ml-1">
             Delete
           </a>

--- a/views/tables.ejs
+++ b/views/tables.ejs
@@ -62,7 +62,7 @@
           <a href='/tables/<%= data[i].TableName %>'>
             <%= data[i].TableName %>
           </a>
-          <a href="#" onClick="deleteTable('<%= data[i].TableName %>')"
+          <a href="#" onClick="deleteTable('<%= data[i].TableName %>'); return false"
               class="badge badge-danger badge-pill float-right ml-1">
             Delete
           </a>


### PR DESCRIPTION
Hello, I stumbled upon a bug where deleting a table refreshes the page and results in an unfinished request to the server. 

While fixing it I also added a small confirm() message to avoid unwillingly deleting a table.