### PR TITLE
Evaluate all pages for ListTables call

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -60,6 +60,7 @@ exports.createServer = (dynamodb, docClient) => {
     docClient = docClient || new AWS.DynamoDB.DocumentClient({service: dynamodb})
   }
 
+  const listTables = promisify(dynamodb.listTables.bind(dynamodb))
   const describeTable = promisify(dynamodb.describeTable.bind(dynamodb))
   const getItem = promisify(docClient.get.bind(docClient))
   const putItem = promisify(docClient.put.bind(docClient))
@@ -69,29 +70,22 @@ exports.createServer = (dynamodb, docClient) => {
   app.use('/assets', express.static(path.join(__dirname, '..', 'public')))
 
   app.get('/', (req, res) => {
-    listTables = (lastEvaluatedTableName, tableNames) => {
-      return new Promise((resolve, reject) => {
-        dynamodb.listTables({ ExclusiveStartTableName: lastEvaluatedTableName }, (error, data) => {
-          if (error) {
-            reject(error)
-          } else {
-            tableNames = tableNames.concat(data.TableNames)
-
-            if (typeof data.LastEvaluatedTableName !== 'undefined') {
-              resolve(listTables(data.LastEvaluatedTableName, tableNames))
-            } else {
-              resolve(Promise.all(
-                tableNames.map(TableName => {
-                  return describeTable({ TableName }).then(data => data.Table)
-                })
-              ))
-            }
+    const listAllTables = (lastEvaluatedTableName, tableNames) => {
+      return listTables({ ExclusiveStartTableName: lastEvaluatedTableName })
+        .then(data => {
+          tableNames = tableNames.concat(data.TableNames)
+          if (typeof data.LastEvaluatedTableName !== 'undefined') {
+            return listAllTables(data.LastEvaluatedTableName, tableNames)
           }
+          return Promise.all(
+            tableNames.map(TableName => {
+              return describeTable({ TableName }).then(data => data.Table)
+            })
+          )
         })
-      })
     }
 
-    listTables(null, [])
+    listAllTables(null, [])
       .then(data => {
         res.render('tables', { data })
       })

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -60,7 +60,6 @@ exports.createServer = (dynamodb, docClient) => {
     docClient = docClient || new AWS.DynamoDB.DocumentClient({service: dynamodb})
   }
 
-  const listTables = promisify(dynamodb.listTables.bind(dynamodb))
   const describeTable = promisify(dynamodb.describeTable.bind(dynamodb))
   const getItem = promisify(docClient.get.bind(docClient))
   const putItem = promisify(docClient.put.bind(docClient))
@@ -70,23 +69,35 @@ exports.createServer = (dynamodb, docClient) => {
   app.use('/assets', express.static(path.join(__dirname, '..', 'public')))
 
   app.get('/', (req, res) => {
-    dynamodb.listTables({}, (error, data) => {
-      if (error) {
+    listTables = (lastEvaluatedTableName, tableNames) => {
+      return new Promise((resolve, reject) => {
+        dynamodb.listTables({ ExclusiveStartTableName: lastEvaluatedTableName }, (error, data) => {
+          if (error) {
+            reject(error)
+          } else {
+            tableNames = tableNames.concat(data.TableNames)
+
+            if (typeof data.LastEvaluatedTableName !== 'undefined') {
+              resolve(listTables(data.LastEvaluatedTableName, tableNames))
+            } else {
+              resolve(Promise.all(
+                tableNames.map(TableName => {
+                  return describeTable({ TableName }).then(data => data.Table)
+                })
+              ))
+            }
+          }
+        })
+      })
+    }
+
+    listTables(null, [])
+      .then(data => {
+        res.render('tables', { data })
+      })
+      .catch(error => {
         res.json({ error })
-      } else {
-        Promise.all(
-          data.TableNames.map(TableName => {
-            return describeTable({ TableName }).then(data => data.Table)
-          })
-        )
-          .then(data => {
-            res.render('tables', { data })
-          })
-          .catch(error => {
-            res.json({ error })
-          })
-      }
-    })
+      })
   })
 
   app.get('/create-table', (req, res) => {


### PR DESCRIPTION
The `ListTables` API call returns [100 entries](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#listTables-property) by default, but some crazy people have lots of tables 🙃 