### PR TITLE
Fix disabled pagination in certain corner-case (#44)

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -297,12 +297,12 @@ exports.createServer = (dynamodb, docClient) => {
           i < items.length && _.size(pageItems) < pageSize + 1;
           i++
         ) {
-          let item = items[i]
-          pageItems.push(item)
+          pageItems.push(items[i])
         }
-        if (_.size(pageItems) >= pageSize || !lastStartKey) {
-          return true
-        } else return false
+        // If there is more items to query (!lastStartKey) then don't stop until
+        // we are over pageSize count. Stopping at exactly pageSize count would
+        // not extract key of last item later and make pagination not work.
+        return _.size(pageItems) > pageSize || !lastStartKey
       }
     )
   }


### PR DESCRIPTION
If multiple chunked scan queries would end up at exactly page size limit (25)
then even if there would be more items to query, we would not enable it.
Fixe by letting the number of items get over the limit which ensures that
the `done` callback slices items to limit and extracts last key.