### PR TITLE
Add support for scanning and querying indexes and some query operators

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -344,7 +344,7 @@ exports.createServer = (dynamodb, docClient) => {
   }))
 
   const getPage = (docClient, keySchema, TableName, scanParams, pageSize,
-                   startKey) => {
+                   startKey, operationType) => {
     const pageItems = []
 
     function onNewItems(items, lastStartKey) {
@@ -358,7 +358,7 @@ exports.createServer = (dynamodb, docClient) => {
       return pageItems.length > pageSize || !lastStartKey
     }
 
-    return doSearch(docClient, TableName, scanParams, 10, startKey, onNewItems)
+    return doSearch(docClient, TableName, scanParams, 10, startKey, onNewItems, operationType)
       .then(items => {
         let nextKey = null
 
@@ -377,36 +377,26 @@ exports.createServer = (dynamodb, docClient) => {
   app.get('/tables/:TableName', asyncMiddleware((req, res) => {
     const TableName = req.params.TableName
     req.query = pickBy(req.query)
-    const filters = omit(req.query, ['_hash', 'range', 'prevKey', 'startKey', 'pageNum'])
+    const filters = JSON.parse(req.query.filters || '{}')
 
     return describeTable({ TableName })
       .then(description => {
         const pageNum = req.query.pageNum ? parseInt(req.query.pageNum) : 1
-        const ExpressionAttributeNames = {}
-        const ExpressionAttributeValues = {}
-        const FilterExpressions = []
-
-        for (const key in filters) {
-          const attributeDefinition = description.Table.AttributeDefinitions.find(
-            definition => {
-              return definition.AttributeName === key
-            }
-          )
-          if (attributeDefinition && attributeDefinition.AttributeType === 'N') {
-            req.query[key] = Number(req.query[key])
-          }
-          ExpressionAttributeNames[`#${key}`] = key
-          ExpressionAttributeValues[`:${key}`] = req.query[key]
-
-          FilterExpressions.push(`#${key} = :${key}`)
-        }
 
         const data = Object.assign({}, description, {
           query: req.query,
           omit,
           filters,
-          pageNum: pageNum,
+          pageNum,
           filterQueryString: querystring.stringify(filters),
+          operators: {
+            '=': '=',
+            '<>': '≠',
+            '>=': '>=',
+            '<=': '<=',
+            '>': '>',
+            '<': '<',
+          },
         })
         res.render('scan', data)
       })
@@ -415,7 +405,7 @@ exports.createServer = (dynamodb, docClient) => {
   app.get('/tables/:TableName/items', asyncMiddleware((req, res) => {
     const TableName = req.params.TableName
     req.query = pickBy(req.query)
-    const filters = omit(req.query, ['_hash', 'range', 'prevKey', 'startKey', 'pageNum'])
+    const filters = req.query.filters ? JSON.parse(req.query.filters) : {}
 
     return describeTable({ TableName })
       .then(description => {
@@ -426,6 +416,15 @@ exports.createServer = (dynamodb, docClient) => {
         const ExpressionAttributeNames = {}
         const ExpressionAttributeValues = {}
         const FilterExpressions = []
+        const KeyConditions = []
+        const KeyConditionExpression = []
+        let indexBeingUsed = null
+
+        if (req.query.operationType === 'query' && req.query.queryableSelection !== 'table') {
+          indexBeingUsed = description.Table.GlobalSecondaryIndexes.find((index) => {
+            return index.IndexName === req.query.queryableSelection
+          })
+        }
 
         for (const key in filters) {
           const attributeDefinition = description.Table.AttributeDefinitions.find(
@@ -434,12 +433,19 @@ exports.createServer = (dynamodb, docClient) => {
             }
           )
           if (attributeDefinition && attributeDefinition.AttributeType === 'N') {
-            req.query[key] = Number(req.query[key])
+            filters[key].value = Number(filters[key].value)
           }
           ExpressionAttributeNames[`#${key}`] = key
-          ExpressionAttributeValues[`:${key}`] = req.query[key]
-
-          FilterExpressions.push(`#${key} = :${key}`)
+          ExpressionAttributeValues[`:${key}`] = filters[key].value
+          if (indexBeingUsed && indexBeingUsed.KeySchema.find(
+            (keySchemaItem) => keySchemaItem.AttributeName === key)
+          ) {
+            KeyConditionExpression.push(`#${key} ${filters[key].operator} :${key}`)
+          } else {
+            ExpressionAttributeNames[`#${key}`] = key
+            ExpressionAttributeValues[`:${key}`] = filters[key].value
+            FilterExpressions.push(`#${key} ${filters[key].operator} :${key}`)
+          }
         }
 
         const params = pickBy({
@@ -452,15 +458,25 @@ exports.createServer = (dynamodb, docClient) => {
             : undefined,
           ExpressionAttributeValues: Object.keys(ExpressionAttributeValues).length
             ? ExpressionAttributeValues
-            : undefined
+            : undefined,
+          KeyConditions: Object.keys(KeyConditions).length
+            ? KeyConditions
+            : undefined,
+          KeyConditionExpression: KeyConditionExpression.length
+            ? KeyConditionExpression.join(' AND ')
+            : undefined,
         })
+
+        if (req.query.queryableSelection && req.query.queryableSelection !== 'table') {
+          params.IndexName = req.query.queryableSelection
+        }
 
         const startKey = Object.keys(ExclusiveStartKey).length
           ? ExclusiveStartKey
           : undefined
 
         return getPage(docClient, description.Table.KeySchema, TableName,
-                       params, 25, startKey)
+                       params, 25, startKey, req.query.operationType)
           .then(results => {
             const { pageItems, nextKey } = results
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -387,7 +387,7 @@ exports.createServer = (dynamodb, docClient) => {
           omit,
           filters,
           pageNum,
-          filterQueryString: encodeURIComponent(req.query.filters),
+          filterQueryString: encodeURIComponent(req.query.filters || ''),
           operators: {
             '=': '=',
             '<>': '≠',
@@ -509,7 +509,7 @@ exports.createServer = (dynamodb, docClient) => {
               prevKey: encodeURIComponent(req.query.prevKey || ''),
               startKey: encodeURIComponent(req.query.startKey || ''),
               nextKey: nextKeyParam,
-              filterQueryString: encodeURIComponent(req.query.filters),
+              filterQueryString: encodeURIComponent(req.query.filters || ''),
               Items: pageItems,
               primaryKeys,
               uniqueKeys,

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -391,6 +391,10 @@ exports.createServer = (dynamodb, docClient) => {
             '>': '>',
             '<': '<',
           },
+          attributeTypes: {
+            'S': 'String',
+            'N': 'Number',
+          },
         })
         res.render('scan', data)
       })
@@ -426,12 +430,7 @@ exports.createServer = (dynamodb, docClient) => {
         }
 
         for (const key in filters) {
-          const attributeDefinition = description.Table.AttributeDefinitions.find(
-            definition => {
-              return definition.AttributeName === key
-            }
-          )
-          if (attributeDefinition && attributeDefinition.AttributeType === 'N') {
+          if (filters[key].type === 'N') {
             filters[key].value = Number(filters[key].value)
           }
           ExpressionAttributeNames[`#${key}`] = key

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -9,7 +9,6 @@ const asyncMiddleware = require('./utils/asyncMiddleware')
 const bodyParser = require('body-parser')
 const pickBy = require('lodash/pickBy')
 const omit = require('lodash/omit')
-const querystring = require('querystring')
 const clc = require('cli-color')
 require('es7-object-polyfill')
 
@@ -388,7 +387,7 @@ exports.createServer = (dynamodb, docClient) => {
           omit,
           filters,
           pageNum,
-          filterQueryString: querystring.stringify(filters),
+          filterQueryString: encodeURIComponent(req.query.filters),
           operators: {
             '=': '=',
             '<>': '≠',
@@ -505,7 +504,7 @@ exports.createServer = (dynamodb, docClient) => {
               prevKey: encodeURIComponent(req.query.prevKey || ''),
               startKey: encodeURIComponent(req.query.startKey || ''),
               nextKey: nextKeyParam,
-              filterQueryString: querystring.stringify(filters),
+              filterQueryString: encodeURIComponent(req.query.filters),
               Items: pageItems,
               primaryKeys,
               uniqueKeys,

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -8,7 +8,6 @@ const { purgeTable } = require('./actions/purgeTable')
 const asyncMiddleware = require('./utils/asyncMiddleware')
 const bodyParser = require('body-parser')
 const pickBy = require('lodash/pickBy')
-const omit = require('lodash/omit')
 const clc = require('cli-color')
 require('es7-object-polyfill')
 
@@ -376,7 +375,6 @@ exports.createServer = (dynamodb, docClient) => {
   app.get('/tables/:TableName', asyncMiddleware((req, res) => {
     const TableName = req.params.TableName
     req.query = pickBy(req.query)
-    const filters = JSON.parse(req.query.filters || '{}')
 
     return describeTable({ TableName })
       .then(description => {
@@ -384,10 +382,7 @@ exports.createServer = (dynamodb, docClient) => {
 
         const data = Object.assign({}, description, {
           query: req.query,
-          omit,
-          filters,
           pageNum,
-          filterQueryString: encodeURIComponent(req.query.filters || ''),
           operators: {
             '=': '=',
             '<>': '≠',
@@ -503,15 +498,12 @@ exports.createServer = (dynamodb, docClient) => {
 
             const data = Object.assign({}, description, {
               query: req.query,
-              omit,
-              filters,
-              pageNum: pageNum,
+              pageNum,
               prevKey: encodeURIComponent(req.query.prevKey || ''),
               startKey: encodeURIComponent(req.query.startKey || ''),
               nextKey: nextKeyParam,
               filterQueryString: encodeURIComponent(req.query.filters || ''),
               Items: pageItems,
-              primaryKeys,
               uniqueKeys,
             })
 

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -417,12 +417,17 @@ exports.createServer = (dynamodb, docClient) => {
         const FilterExpressions = []
         const KeyConditions = []
         const KeyConditionExpression = []
+        const queryableSelection = req.query.queryableSelection || 'table'
         let indexBeingUsed = null
 
-        if (req.query.operationType === 'query' && req.query.queryableSelection !== 'table') {
-          indexBeingUsed = description.Table.GlobalSecondaryIndexes.find((index) => {
-            return index.IndexName === req.query.queryableSelection
-          })
+        if (req.query.operationType === 'query') {
+          if (queryableSelection === 'table') {
+            indexBeingUsed = description.Table
+          } else if (description.Table.GlobalSecondaryIndexes) {
+            indexBeingUsed = description.Table.GlobalSecondaryIndexes.find((index) => {
+              return index.IndexName === req.query.queryableSelection
+            })
+          }
         }
 
         for (const key in filters) {

--- a/views/get.ejs
+++ b/views/get.ejs
@@ -18,9 +18,10 @@
     <ul class='nav nav-tabs'>
       <li class='nav-item'>
         <a class='nav-link' href='/tables/<%= Table.TableName %>'>
-          Scan
+          Items
         </a>
-      </li><li class="nav-item">
+      </li>
+      <li class="nav-item">
         <a class="nav-link active" href="/tables/<%= Table.TableName %>/get">
           Get
         </a>

--- a/views/meta.ejs
+++ b/views/meta.ejs
@@ -19,9 +19,10 @@
     <ul class='nav nav-tabs'>
       <li class='nav-item'>
         <a class='nav-link' href='/tables/<%= Table.TableName %>'>
-          Scan
+          Items
         </a>
-      </li><li class="nav-item">
+      </li>
+      <li class="nav-item">
         <a class="nav-link" href="/tables/<%= Table.TableName %>/get">
           Get
         </a>

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -122,7 +122,6 @@
                   <% Table.KeySchema.forEach(keySchemaItem => { %>
                     data-key-<%= keySchemaItem.KeyType.toLowerCase() %>="<%= keySchemaItem.AttributeName %>"
                   <% }) %>
-                  <% if (sortKey) { %> data-sort-key="<%= sortKey.AttributeName %>" <% } %>
                   <% if (query.queryableSelection === 'table') { %> selected<% } %>
                 >[Table] <%= Table.TableName %></option>
                 <% if (Table.GlobalSecondaryIndexes) { %>

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -446,14 +446,14 @@
             const rangeKey = option.getAttribute('data-key-range')
 
             if (filterKey === hashKey) {
-              addHashKeyFilter(filterKey, filterParams.value)
+              addHashKeyFilter(filterKey, filterParams.value, filterParams.operator)
             } else if (filterKey === rangeKey) {
-              addRangeKeyFilter(filterKey, filterParams.value)
+              addRangeKeyFilter(filterKey, filterParams.value, filterParams.operator)
             } else {
-              addFilter(filterKey, filterParams.value)
+              addFilter(filterKey, filterParams.value, filterParams.operator)
             }
           } else {
-            addFilter(filterKey, filterParams.value)
+            addFilter(filterKey, filterParams.value, filterParams.operator)
           }
         }
       }

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -272,7 +272,6 @@
       if (event.target.value === 'query') {
         const querySelection = document.querySelector('select[name="queryableSelection"]')
         const option = querySelection.selectedOptions[0]
-        // const requiredKeys = option.getAttribute('data-required-query-keys')
         const hashKey = option.getAttribute('data-key-hash')
         const rangeKey = option.getAttribute('data-key-range')
 

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -128,7 +128,7 @@
                   <% for (const index of Table.GlobalSecondaryIndexes) { %>
                     <% const attributes = index.KeySchema.map((keySchemaItem) => keySchemaItem.AttributeName) %>
                     <option value="<%= index.IndexName %>"
-                      <% Table.KeySchema.forEach(keySchemaItem => { %>
+                      <% index.KeySchema.forEach(keySchemaItem => { %>
                         data-key-<%= keySchemaItem.KeyType.toLowerCase() %>="<%= keySchemaItem.AttributeName %>"
                       <% }) %>
                       <% if (query.queryableSelection === index.IndexName) { %> selected<% } %>
@@ -149,46 +149,6 @@
             <td>
               <table id="filters-table" class="table table-bordered">
                 <tbody>
-                  <% for (let filterKey in filters) { %>
-                    <tr>
-                      <td style="width: 95px;">
-                        <button
-                          type="button"
-                          onclick="removeFilter(this)"
-                          <% if (filters[filterKey].required) { %> hidden <% } %>
-                          class="filter-remove btn btn-danger"
-                        >Remove</button>
-                      </td>
-                      <td style="width: 300px">
-                        <input
-                          type="text"
-                          class="form-control filter-row-key"
-                          <% if (filters[filterKey].required) { %> required="required" readonly <% } %>
-                          value="<%= filterKey %>"
-                        />
-                      </td>
-                      <td>
-                        <select class="form-control filter-row-operator">
-                          <% for (const operator in operators) { %>
-                            <option value="<%= operator %>"
-                              <% if (filters[filterKey].operator === operator) { %>
-                                selected
-                              <% } %>
-                              ><%= operators[operator] %></option>
-                          <% } %>
-                        </select>
-                      </td>
-                      <td>
-                        <input
-                          type="text"
-                          class="form-control filter-row-value"
-                          placeholder="Value"
-                          <% if (filters[filterKey].required) { %> required <% } %>
-                          value="<%= filters[filterKey].value %>"
-                        />
-                      </td>
-                    </tr>
-                  <% } %>
                   <tr>
                     <td style="width: 95px;">
                       <button type="button" onclick="removeFilter(this)" class="filter-remove btn btn-danger">Remove</button>
@@ -260,7 +220,6 @@
           filters[keyField.value] = {
             operator: operatorField.value,
             value: valueField.value,
-            required: !!keyField.getAttribute('required'),
           }
         }
       })
@@ -268,33 +227,20 @@
       form.filters.value = JSON.stringify(filters)
     })
 
+    document.querySelector('select[name="queryableSelection"]').addEventListener('change', (event) => {
+      const operationType = document.querySelector('select[name="operationType"]')
+
+      if (operationType.value === 'query') {
+        unrequireAllFilters()
+        requireIndexFilters()
+      }
+    })
+
     document.querySelector('select[name="operationType"]').addEventListener('change', (event) => {
       if (event.target.value === 'query') {
-        const querySelection = document.querySelector('select[name="queryableSelection"]')
-        const option = querySelection.selectedOptions[0]
-        const hashKey = option.getAttribute('data-key-hash')
-        const rangeKey = option.getAttribute('data-key-range')
-
-        if (hashKey) {
-          addFilter(hashKey, true, ['='])
-        }
-
-        if (rangeKey) {
-          addFilter(rangeKey, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
-        }
+        requireIndexFilters()
       } else {
-        document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
-          const keyField = filterRow.querySelector('.filter-row-key')
-          keyField.removeAttribute('required')
-          keyField.removeAttribute('readonly')
-          filterRow.querySelector('.filter-row-value').removeAttribute('required')
-          filterRow.querySelector('.filter-remove').removeAttribute('hidden')
-          const operatorField = filterRow.querySelector('.filter-row-operator')
-          operatorField.removeAttribute('disabled')
-          operatorField.querySelectorAll('option').forEach((option) => {
-            option.removeAttribute('disabled')
-          })
-        })
+        unrequireAllFilters()
       }
     })
 
@@ -303,7 +249,37 @@
       addFilter()
     })
 
-    function addFilter (key, required, availableOperators) {
+    function requireIndexFilters () {
+      const querySelection = document.querySelector('select[name="queryableSelection"]')
+      const option = querySelection.selectedOptions[0]
+      const hashKey = option.getAttribute('data-key-hash')
+      const rangeKey = option.getAttribute('data-key-range')
+
+      if (hashKey) {
+        addHashKeyFilter(hashKey)
+      }
+
+      if (rangeKey) {
+        addRangeKeyFilter(rangeKey)
+      }
+    }
+
+    function unrequireAllFilters () {
+      document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
+        const keyField = filterRow.querySelector('.filter-row-key')
+        keyField.removeAttribute('required')
+        keyField.removeAttribute('readonly')
+        filterRow.querySelector('.filter-row-value').removeAttribute('required')
+        filterRow.querySelector('.filter-remove').removeAttribute('hidden')
+        const operatorField = filterRow.querySelector('.filter-row-operator')
+        operatorField.removeAttribute('disabled')
+        operatorField.querySelectorAll('option').forEach((option) => {
+          option.removeAttribute('disabled')
+        })
+      })
+    }
+
+    function addFilter (key, filterValue, operatorValue, required, availableOperators) {
       let filterRow
       let lastRow
       if (key) {
@@ -317,7 +293,7 @@
       if (!filterRow) {
         lastRow = document.querySelector('#filters-table tr:last-child')
         filterRow = lastRow.cloneNode(true)
-        filterRow.querySelector('.filter-row-value').value = ''
+        filterRow.querySelector('.filter-row-value').value = filterValue || ''
       }
 
       const keyField = filterRow.querySelector('.filter-row-key')
@@ -336,6 +312,11 @@
       }
 
       const operatorField = filterRow.querySelector('.filter-row-operator')
+
+      if (operatorValue) {
+        operatorField.value = operatorValue
+      }
+
       operatorField.querySelectorAll('option').forEach((option) => {
         const enabled = availableOperators ? availableOperators.includes(option.value) : true
         if (enabled) {
@@ -358,6 +339,14 @@
       if (lastRow) {
         document.querySelector('#filters-table tbody').appendChild(filterRow)
       }
+    }
+
+    function addHashKeyFilter (hashKey, searchValue, operatorValue) {
+      addFilter(hashKey, searchValue, operatorValue, true, ['='])
+    }
+
+    function addRangeKeyFilter (rangeKey, searchValue, operatorValue) {
+      addFilter(rangeKey, searchValue, operatorValue, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
     }
 
     function removeFilter (node) {
@@ -438,6 +427,37 @@
     }
 
     window.addEventListener('load', () => {
+      const startOfNextQueryParam = location.search.substr(location.search.indexOf('filters=')).indexOf('&')
+      const queryStringFilters = location.search.substr(location.search.indexOf('filters='), startOfNextQueryParam === -1 ? undefined : startOfNextQueryParam).substr(8)
+
+      if (queryStringFilters.length > 0) {
+        let queryFilters = {}
+        try {
+          queryFilters = JSON.parse(decodeURIComponent(queryStringFilters))
+        } catch (ex) {}
+
+        const operationType = document.querySelector('select[name="operationType"]').value
+        for (const filterKey of Object.keys(queryFilters)) {
+          const filterParams = queryFilters[filterKey]
+          if (operationType === 'query') {
+            const querySelection = document.querySelector('select[name="queryableSelection"]')
+            const option = querySelection.selectedOptions[0]
+            const hashKey = option.getAttribute('data-key-hash')
+            const rangeKey = option.getAttribute('data-key-range')
+
+            if (filterKey === hashKey) {
+              addHashKeyFilter(filterKey, filterParams.value)
+            } else if (filterKey === rangeKey) {
+              addRangeKeyFilter(filterKey, filterParams.value)
+            } else {
+              addFilter(filterKey, filterParams.value)
+            }
+          } else {
+            addFilter(filterKey, filterParams.value)
+          }
+        }
+      }
+
       fetch(document.location.pathname + '/items' + document.location.search)
         .then(response => response.json())
         .then(json => {

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -119,13 +119,19 @@
             <td>
               <select name="queryableSelection"<% if (!Table.GlobalSecondaryIndexes) { %> disabled<% } %>>
                 <option value="table"
-                  data-required-query-keys="<%= Table.KeySchema.map(keySchemaItem => keySchemaItem.AttributeName).join(',') %>"
+                  <% Table.KeySchema.forEach(keySchemaItem => { %>
+                    data-key-<%= keySchemaItem.KeyType.toLowerCase() %>="<%= keySchemaItem.AttributeName %>"
+                  <% }) %>
+                  <% if (sortKey) { %> data-sort-key="<%= sortKey.AttributeName %>" <% } %>
                   <% if (query.queryableSelection === 'table') { %> selected<% } %>
                 >[Table] <%= Table.TableName %></option>
                 <% if (Table.GlobalSecondaryIndexes) { %>
                   <% for (const index of Table.GlobalSecondaryIndexes) { %>
                     <% const attributes = index.KeySchema.map((keySchemaItem) => keySchemaItem.AttributeName) %>
-                    <option value="<%= index.IndexName %>" data-required-query-keys="<%= attributes.join(',') %>"
+                    <option value="<%= index.IndexName %>"
+                      <% Table.KeySchema.forEach(keySchemaItem => { %>
+                        data-key-<%= keySchemaItem.KeyType.toLowerCase() %>="<%= keySchemaItem.AttributeName %>"
+                      <% }) %>
                       <% if (query.queryableSelection === index.IndexName) { %> selected<% } %>
                       >[Index] <%= index.IndexName %>: <%= attributes.join(', ') %>
                     </option>
@@ -267,12 +273,16 @@
       if (event.target.value === 'query') {
         const querySelection = document.querySelector('select[name="queryableSelection"]')
         const option = querySelection.selectedOptions[0]
-        const requiredKeys = option.getAttribute('data-required-query-keys')
+        // const requiredKeys = option.getAttribute('data-required-query-keys')
+        const hashKey = option.getAttribute('data-key-hash')
+        const rangeKey = option.getAttribute('data-key-range')
 
-        if (requiredKeys && requiredKeys.length > 0) {
-          for (const requiredKey of requiredKeys.split(',')) {
-            addFilter(requiredKey, true)
-          }
+        if (hashKey) {
+          addFilter(hashKey, true, ['='])
+        }
+
+        if (rangeKey) {
+          addFilter(rangeKey, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
         }
       } else {
         document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
@@ -281,6 +291,11 @@
           keyField.removeAttribute('readonly')
           filterRow.querySelector('.filter-row-value').removeAttribute('required')
           filterRow.querySelector('.filter-remove').removeAttribute('hidden')
+          const operatorField = filterRow.querySelector('.filter-row-operator')
+          operatorField.removeAttribute('disabled')
+          operatorField.querySelectorAll('option').forEach((option) => {
+            option.removeAttribute('disabled')
+          })
         })
       }
     })
@@ -290,7 +305,7 @@
       addFilter()
     })
 
-    function addFilter (key, required) {
+    function addFilter (key, required, availableOperators) {
       let filterRow
       let lastRow
       if (key) {
@@ -320,6 +335,26 @@
         keyField.removeAttribute('readonly')
         filterRow.querySelector('.filter-row-value').removeAttribute('required')
         filterRow.querySelector('.filter-remove').removeAttribute('hidden')
+      }
+
+      const operatorField = filterRow.querySelector('.filter-row-operator')
+      operatorField.querySelectorAll('option').forEach((option) => {
+        const enabled = availableOperators ? availableOperators.includes(option.value) : true
+        if (enabled) {
+          option.removeAttribute('disabled')
+        } else {
+          option.setAttribute('disabled', true)
+        }
+      })
+
+      if (availableOperators && !availableOperators.includes(operatorField.value)) {
+        operatorField.value = availableOperators[0]
+      }
+
+      if (availableOperators && availableOperators.length === 1) {
+        operatorField.setAttribute('disabled', true)
+      } else {
+        operatorField.removeAttribute('disabled')
       }
 
       if (lastRow) {

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -77,7 +77,7 @@
     <ul class="nav nav-tabs">
       <li class="nav-item">
         <a class="nav-link active item-count" href="/tables/<%= Table.TableName %>">
-          Scan
+          Items
         </a>
       </li>
       <li class="nav-item">
@@ -110,6 +110,31 @@
       <table class="table table-bordered">
         <tbody>
           <tr>
+            <th>
+              <select name="operationType">
+                <option value="scan"<% if (query.operationType === 'scan') { %> selected<% } %>>Scan</option>
+                <option value="query"<% if (query.operationType === 'query') { %> selected<% } %>>Query</option>
+              </select>
+            </th>
+            <td>
+              <select name="queryableSelection">
+                <option value="table"<% if (query.queryableSelection === 'table') { %> selected<% } %>>[Table] <%= Table.TableName %></option>
+                <% for (const index of Table.GlobalSecondaryIndexes) { %>
+                  <option value="<%= index.IndexName %>"
+                    <% if (query.queryableSelection === index.IndexName) { %> selected<% } %>
+                    >[Index] <%= index.IndexName %><%
+                    if (index.KeySchema) {
+                      const attributes = index.KeySchema.map((keySchemaItem) => keySchemaItem.AttributeName);
+                      %>
+                      : <%= attributes.join(', '); %>
+                      <%
+                    }
+                  %></option>
+                <% } %>
+              </select>
+            </td>
+          </tr>
+          <tr>
             <th>Filter</th>
             <td>
               <table class="table table-bordered">
@@ -131,8 +156,14 @@
                         />
                       </td>
                       <td>
-                        <select class="form-control" readonly>
-                          <option>=</option>
+                        <select class="form-control" id="<%= filterKey %>Operator">
+                          <% for (const operator in operators) { %>
+                            <option value="<%= operator %>"
+                              <% if (filters[filterKey].operator === operator) { %>
+                                selected
+                              <% } %>
+                              ><%= operators[operator] %></option>
+                          <% } %>
                         </select>
                       </td>
                       <td>
@@ -140,8 +171,8 @@
                           type="text"
                           class="form-control"
                           placeholder="Value"
-                          name="<%= filterKey %>"
-                          value="<%= filters[filterKey] %>"
+                          id="<%= filterKey %>Value"
+                          value="<%= filters[filterKey].value %>"
                         />
                       </td>
                     </tr>
@@ -150,7 +181,6 @@
                     <td style="width: 95px;"></td>
                     <td style="width: 300px">
                       <input
-                        data-filter-key
                         type="text"
                         class="form-control"
                         id="key"
@@ -159,8 +189,10 @@
                       />
                     </td>
                     <td>
-                      <select class="form-control" readonly>
-                        <option>=</option>
+                      <select class="form-control" id="operator">
+                        <% for (const operator in operators) { %>
+                          <option value="<%= operator %>"><%= operators[operator] %></option>
+                        <% } %>
                       </select>
                     </td>
                     <td>
@@ -173,7 +205,7 @@
           </tr>
         </tbody>
       </table>
-      <input id="param" type="hidden" />
+      <input id="filters" name="filters" type="hidden" />
 
       <div class="row">
         <div class="col-md-6">
@@ -204,8 +236,24 @@
 
     const form = document.querySelector('#form')
     form.addEventListener('submit', () => {
-      form.param.setAttribute('name', form.key.value)
-      form.param.value = form.value.value
+      const filters = {}
+
+      $('input[data-filter-key]').each((i, input) => {
+        const filterKey = input.value
+        filters[filterKey] = {
+          operator: document.getElementById(`${filterKey}Operator`).value,
+          value: document.getElementById(`${filterKey}Value`).value,
+        }
+      })
+
+      if (form.key.value) {
+        filters[form.key.value] = {
+          operator: form.operator.value,
+          value: form.value.value,
+        }
+      }
+
+      form.filters.value = JSON.stringify(filters)
     })
     function removeFilter (node) {
       node.closest('tr').remove()
@@ -252,13 +300,13 @@
 
         if (data.pageNum > 1) {
           $('.page-link-previous')
-            .attr('href', '?startKey=' + data.prevKey + '&pageNum=' + (data.pageNum-1) + '&'  + data.filterQueryString)
-          $('.page-item-previous').removeClass('disabled')
+            .attr('href', '?startKey=' + data.prevKey + '&pageNum=' + (data.pageNum-1) + '&' + data.filterQueryString)
+         $('.page-item-previous').removeClass('disabled')
         }
 
         if (data.nextKey) {
           $('.page-link-next')
-            .attr('href', '?startKey=' + data.nextKey + '&prevKey=' + data.prevKey + '&pageNum=' + (data.pageNum+1) + '&'  + data.filterQueryString)
+            .attr('href', '?startKey=' + data.nextKey + '&prevKey=' + data.prevKey + '&pageNum=' + (data.pageNum+1) + '&' + data.filterQueryString)
           $('.page-item-next').removeClass('disabled')
         }
 

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -324,7 +324,14 @@
     }
 
     function removeFilter (node) {
-      node.closest('tr').remove()
+      // prevent removal of the last filter row, instead, just clear it out
+      if (document.querySelectorAll('#filters-table tr').length === 1) {
+        const filterRow = document.querySelector('#filters-table tr')
+        filterRow.querySelector('.filter-row-key').value = ''
+        filterRow.querySelector('.filter-row-value').value = ''
+      } else {
+        node.closest('tr').remove()
+      }
     }
 
     function updateFilterAutocomplete(uniqueKeys) {

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -111,13 +111,13 @@
         <tbody>
           <tr>
             <th>
-              <select name="operationType">
+              <select name="operationType" class="form-control">
                 <option value="scan"<% if (query.operationType === 'scan') { %> selected<% } %>>Scan</option>
                 <option value="query"<% if (query.operationType === 'query') { %> selected<% } %>>Query</option>
               </select>
             </th>
             <td>
-              <select name="queryableSelection"<% if (!Table.GlobalSecondaryIndexes) { %> disabled<% } %>>
+              <select name="queryableSelection" class="form-control"<% if (!Table.GlobalSecondaryIndexes) { %> disabled<% } %>>
                 <option value="table"
                   <% Table.KeySchema.forEach(keySchemaItem => { %>
                     data-key-<%= keySchemaItem.KeyType.toLowerCase() %>="<%= keySchemaItem.AttributeName %>"
@@ -161,14 +161,14 @@
                         list="attributes"
                       />
                     </td>
-                    <td>
+                    <td style="width: 125px">
                       <select class="form-control filter-row-type">
                         <% for (const type in attributeTypes) { %>
                           <option value="<%= type %>"><%= attributeTypes[type] %></option>
                         <% } %>
                       </select>
                     </td>
-                    <td>
+                    <td style="width: 80px">
                       <select class="form-control filter-row-operator">
                         <% for (const operator in operators) { %>
                           <option value="<%= operator %>"><%= operators[operator] %></option>

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -117,19 +117,19 @@
               </select>
             </th>
             <td>
-              <select name="queryableSelection">
-                <option value="table"<% if (query.queryableSelection === 'table') { %> selected<% } %>>[Table] <%= Table.TableName %></option>
-                <% for (const index of Table.GlobalSecondaryIndexes) { %>
-                  <option value="<%= index.IndexName %>"
-                    <% if (query.queryableSelection === index.IndexName) { %> selected<% } %>
-                    >[Index] <%= index.IndexName %><%
-                    if (index.KeySchema) {
-                      const attributes = index.KeySchema.map((keySchemaItem) => keySchemaItem.AttributeName);
-                      %>
-                      : <%= attributes.join(', '); %>
-                      <%
-                    }
-                  %></option>
+              <select name="queryableSelection"<% if (!Table.GlobalSecondaryIndexes) { %> disabled<% } %>>
+                <option value="table"
+                  data-required-query-keys="<%= Table.KeySchema.map(keySchemaItem => keySchemaItem.AttributeName).join(',') %>"
+                  <% if (query.queryableSelection === 'table') { %> selected<% } %>
+                >[Table] <%= Table.TableName %></option>
+                <% if (Table.GlobalSecondaryIndexes) { %>
+                  <% for (const index of Table.GlobalSecondaryIndexes) { %>
+                    <% const attributes = index.KeySchema.map((keySchemaItem) => keySchemaItem.AttributeName) %>
+                    <option value="<%= index.IndexName %>" data-required-query-keys="<%= attributes.join(',') %>"
+                      <% if (query.queryableSelection === index.IndexName) { %> selected<% } %>
+                      >[Index] <%= index.IndexName %>: <%= attributes.join(', ') %>
+                    </option>
+                  <% } %>
                 <% } %>
               </select>
             </td>
@@ -137,26 +137,28 @@
           <tr>
             <th>Filter</th>
             <td>
-              <table class="table table-bordered">
+              <table id="filters-table" class="table table-bordered">
                 <tbody>
                   <% for (let filterKey in filters) { %>
                     <tr>
                       <td style="width: 95px;">
-                        <button type="button" onclick="removeFilter(this)" class='btn btn-danger'>Remove</button>
+                        <button
+                          type="button"
+                          onclick="removeFilter(this)"
+                          <% if (filters[filterKey].required) { %> hidden <% } %>
+                          class="filter-remove btn btn-danger"
+                        >Remove</button>
                       </td>
-                      <td
-                        style="width: 300px"
-                      >
+                      <td style="width: 300px">
                         <input
-                          data-filter-key
                           type="text"
-                          class="form-control"
-                          readonly
+                          class="form-control filter-row-key"
+                          <% if (filters[filterKey].required) { %> required readonly <% } %>
                           value="<%= filterKey %>"
                         />
                       </td>
                       <td>
-                        <select class="form-control" id="<%= filterKey %>Operator">
+                        <select class="form-control filter-row-operator">
                           <% for (const operator in operators) { %>
                             <option value="<%= operator %>"
                               <% if (filters[filterKey].operator === operator) { %>
@@ -169,34 +171,35 @@
                       <td>
                         <input
                           type="text"
-                          class="form-control"
+                          class="form-control filter-row-value"
                           placeholder="Value"
-                          id="<%= filterKey %>Value"
+                          <% if (filters[filterKey].required) { %> required <% } %>
                           value="<%= filters[filterKey].value %>"
                         />
                       </td>
                     </tr>
                   <% } %>
                   <tr>
-                    <td style="width: 95px;"></td>
+                    <td style="width: 95px;">
+                      <button type="button" onclick="removeFilter(this)" class="filter-remove btn btn-danger">Remove</button>
+                    </td>
                     <td style="width: 300px">
                       <input
                         type="text"
-                        class="form-control"
-                        id="key"
+                        class="form-control filter-row-key"
                         placeholder="Key"
                         list="attributes"
                       />
                     </td>
                     <td>
-                      <select class="form-control" id="operator">
+                      <select class="form-control filter-row-operator">
                         <% for (const operator in operators) { %>
                           <option value="<%= operator %>"><%= operators[operator] %></option>
                         <% } %>
                       </select>
                     </td>
                     <td>
-                      <input id="value" type="text" class="form-control" placeholder="Value" />
+                      <input id="value" type="text" class="form-control filter-row-value" placeholder="Value" />
                     </td>
                   </tr>
                 </tbody>
@@ -209,7 +212,8 @@
 
       <div class="row">
         <div class="col-md-6">
-          <button type="submit" class="btn btn-primary">Scan</button>
+          <button type="submit" class="btn btn-primary">Search</button>
+          <button id="add-filter" class="btn btn-secondary">Add Filter</button>
         </div>
 
         <div class="col-md-6 pagination-container d-none">
@@ -238,23 +242,87 @@
     form.addEventListener('submit', () => {
       const filters = {}
 
-      $('input[data-filter-key]').each((i, input) => {
-        const filterKey = input.value
-        filters[filterKey] = {
-          operator: document.getElementById(`${filterKey}Operator`).value,
-          value: document.getElementById(`${filterKey}Value`).value,
+      document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
+        const keyField = filterRow.querySelector('.filter-row-key')
+        const operatorField = filterRow.querySelector('.filter-row-operator')
+        const valueField = filterRow.querySelector('.filter-row-value')
+
+        if (keyField.value && valueField.value) {
+          filters[keyField.value] = {
+            operator: operatorField.value,
+            value: valueField.value,
+            required: !!keyField.getAttribute('required'),
+          }
         }
       })
 
-      if (form.key.value) {
-        filters[form.key.value] = {
-          operator: form.operator.value,
-          value: form.value.value,
-        }
-      }
-
       form.filters.value = JSON.stringify(filters)
     })
+
+    document.querySelector('select[name="operationType"]').addEventListener('change', (event) => {
+      if (event.target.value === 'query') {
+        const querySelection = document.querySelector('select[name="queryableSelection"]')
+        const option = querySelection.selectedOptions[0]
+        const requiredKeys = option.getAttribute('data-required-query-keys')
+
+        if (requiredKeys && requiredKeys.length > 0) {
+          for (const requiredKey of requiredKeys.split(',')) {
+            addFilter(requiredKey, true)
+          }
+        }
+      } else {
+        document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
+          const keyField = filterRow.querySelector('.filter-row-key')
+          keyField.removeAttribute('required')
+          keyField.removeAttribute('readonly')
+          filterRow.querySelector('.filter-row-value').removeAttribute('required')
+          filterRow.querySelector('.filter-remove').removeAttribute('hidden')
+        })
+      }
+    })
+
+    document.querySelector('#add-filter').addEventListener('click', (event) => {
+      event.preventDefault()
+      addFilter()
+    })
+
+    function addFilter (key, required) {
+      let filterRow
+      let lastRow
+      if (key) {
+        document.querySelectorAll('#filters-table tr').forEach((row) => {
+          if (row.querySelector('.filter-row-key').value === key) {
+            filterRow = row
+          }
+        })
+      }
+
+      if (!filterRow) {
+        lastRow = document.querySelector('#filters-table tr:last-child')
+        filterRow = lastRow.cloneNode(true)
+        filterRow.querySelector('.filter-row-value').value = ''
+      }
+
+      const keyField = filterRow.querySelector('.filter-row-key')
+      keyField.value = key || ''
+
+      if (required) {
+        keyField.setAttribute('required', true)
+        keyField.setAttribute('readonly', true)
+        filterRow.querySelector('.filter-row-value').setAttribute('required', true)
+        filterRow.querySelector('.filter-remove').setAttribute('hidden', true)
+      } else {
+        keyField.removeAttribute('required')
+        keyField.removeAttribute('readonly')
+        filterRow.querySelector('.filter-row-value').removeAttribute('required')
+        filterRow.querySelector('.filter-remove').removeAttribute('hidden')
+      }
+
+      if (lastRow) {
+        document.querySelector('#filters-table tbody').appendChild(filterRow)
+      }
+    }
+
     function removeFilter (node) {
       node.closest('tr').remove()
     }
@@ -300,19 +368,19 @@
 
         if (data.pageNum > 1) {
           $('.page-link-previous')
-            .attr('href', '?startKey=' + data.prevKey + '&pageNum=' + (data.pageNum-1) + '&' + data.filterQueryString)
-         $('.page-item-previous').removeClass('disabled')
+            .attr('href', '?startKey=' + data.prevKey + '&pageNum=' + (data.pageNum-1) + '&filters=' + data.filterQueryString)
+          $('.page-item-previous').removeClass('disabled')
         }
 
         if (data.nextKey) {
           $('.page-link-next')
-            .attr('href', '?startKey=' + data.nextKey + '&prevKey=' + data.prevKey + '&pageNum=' + (data.pageNum+1) + '&' + data.filterQueryString)
+            .attr('href', '?startKey=' + data.nextKey + '&prevKey=' + data.prevKey + '&pageNum=' + (data.pageNum+1) + '&filters=' + data.filterQueryString)
           $('.page-item-next').removeClass('disabled')
         }
 
         const rangeFrom = ((data.pageNum - 1) * 25) + 1
         const rangeTo = rangeFrom + (data.Items.length - 1)
-        $('.item-count').append(' (showing items ' + rangeFrom + ' - ' + rangeTo + ')')
+        $('.item-count').append(' (showing ' + rangeFrom + ' - ' + rangeTo + ')')
 
         $('.table-container').removeClass('d-none')
         $('.pagination-container').removeClass('d-none')

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -153,7 +153,7 @@
                         <input
                           type="text"
                           class="form-control filter-row-key"
-                          <% if (filters[filterKey].required) { %> required readonly <% } %>
+                          <% if (filters[filterKey].required) { %> required="required" readonly <% } %>
                           value="<%= filterKey %>"
                         />
                       </td>

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -162,6 +162,13 @@
                       />
                     </td>
                     <td>
+                      <select class="form-control filter-row-type">
+                        <% for (const type in attributeTypes) { %>
+                          <option value="<%= type %>"><%= attributeTypes[type] %></option>
+                        <% } %>
+                      </select>
+                    </td>
+                    <td>
                       <select class="form-control filter-row-operator">
                         <% for (const operator in operators) { %>
                           <option value="<%= operator %>"><%= operators[operator] %></option>
@@ -213,6 +220,7 @@
 
       document.querySelectorAll('#filters-table tr').forEach((filterRow) => {
         const keyField = filterRow.querySelector('.filter-row-key')
+        const typeField = filterRow.querySelector('.filter-row-type')
         const operatorField = filterRow.querySelector('.filter-row-operator')
         const valueField = filterRow.querySelector('.filter-row-value')
 
@@ -220,6 +228,7 @@
           filters[keyField.value] = {
             operator: operatorField.value,
             value: valueField.value,
+            type: typeField.value,
           }
         }
       })
@@ -279,7 +288,7 @@
       })
     }
 
-    function addFilter (key, filterValue, operatorValue, required, availableOperators) {
+    function addFilter (key, values, required, availableOperators) {
       let filterRow
       let lastRow
       if (key) {
@@ -293,7 +302,7 @@
       if (!filterRow) {
         lastRow = document.querySelector('#filters-table tr:last-child')
         filterRow = lastRow.cloneNode(true)
-        filterRow.querySelector('.filter-row-value').value = filterValue || ''
+        filterRow.querySelector('.filter-row-value').value = values && values.value ? values.value : ''
       }
 
       const keyField = filterRow.querySelector('.filter-row-key')
@@ -311,10 +320,15 @@
         filterRow.querySelector('.filter-remove').removeAttribute('hidden')
       }
 
+      if (values && values.type) {
+        const typeField = filterRow.querySelector('.filter-row-type')
+        typeField.value = values.type
+      }
+
       const operatorField = filterRow.querySelector('.filter-row-operator')
 
-      if (operatorValue) {
-        operatorField.value = operatorValue
+      if (values && values.operator) {
+        operatorField.value = values.operator
       }
 
       operatorField.querySelectorAll('option').forEach((option) => {
@@ -341,12 +355,12 @@
       }
     }
 
-    function addHashKeyFilter (hashKey, searchValue, operatorValue) {
-      addFilter(hashKey, searchValue, operatorValue, true, ['='])
+    function addHashKeyFilter (hashKey, values) {
+      addFilter(hashKey, values, true, ['='])
     }
 
-    function addRangeKeyFilter (rangeKey, searchValue, operatorValue) {
-      addFilter(rangeKey, searchValue, operatorValue, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
+    function addRangeKeyFilter (rangeKey, values) {
+      addFilter(rangeKey, values, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
     }
 
     function removeFilter (node) {
@@ -446,14 +460,14 @@
             const rangeKey = option.getAttribute('data-key-range')
 
             if (filterKey === hashKey) {
-              addHashKeyFilter(filterKey, filterParams.value, filterParams.operator)
+              addHashKeyFilter(filterKey, filterParams)
             } else if (filterKey === rangeKey) {
-              addRangeKeyFilter(filterKey, filterParams.value, filterParams.operator)
+              addRangeKeyFilter(filterKey, filterParams)
             } else {
-              addFilter(filterKey, filterParams.value, filterParams.operator)
+              addFilter(filterKey, filterParams)
             }
           } else {
-            addFilter(filterKey, filterParams.value, filterParams.operator)
+            addFilter(filterKey, filterParams)
           }
         }
       }

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -135,7 +135,12 @@
             </td>
           </tr>
           <tr>
-            <th>Filter</th>
+            <th>
+              Filter
+              <div style="margin-top: 1em">
+                <button id="add-filter" class="btn btn-secondary">Add Filter</button>
+              </div>
+            </th>
             <td>
               <table id="filters-table" class="table table-bordered">
                 <tbody>
@@ -213,7 +218,6 @@
       <div class="row">
         <div class="col-md-6">
           <button type="submit" class="btn btn-primary">Search</button>
-          <button id="add-filter" class="btn btn-secondary">Add Filter</button>
         </div>
 
         <div class="col-md-6 pagination-container d-none">


### PR DESCRIPTION
This adds some basic support for scanning and querying indexes, helpful
when developing with indexes to see what data is being projected into
a index or to test queries.

It adds basic support for some query operators beyond the "is equal"
comparison, but this does not add rich operators like BETWEEN, begins
with, attribute exists, attribute does not exist, NULL, NOT, NULL, IN,
NOT IN, or the contains operators.

Renamed the "Scan" page to "Items", since Scan does not sound
appropriate given the new capabilities.