### PR TITLE
fix: escape keys properly for expression attribute names

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -428,21 +428,25 @@ exports.createServer = (dynamodb, docClient) => {
           }
         }
 
+        // Create a variable to uniquely identify each expression attribute
+        let i = 0
         for (const key in filters) {
           if (filters[key].type === 'N') {
             filters[key].value = Number(filters[key].value)
           }
-          ExpressionAttributeNames[`#${key}`] = key
-          ExpressionAttributeValues[`:${key}`] = filters[key].value
+          ExpressionAttributeNames[`#key${i}`] = key
+          ExpressionAttributeValues[`:key${i}`] = filters[key].value
           if (indexBeingUsed && indexBeingUsed.KeySchema.find(
             (keySchemaItem) => keySchemaItem.AttributeName === key)
           ) {
-            KeyConditionExpression.push(`#${key} ${filters[key].operator} :${key}`)
+            KeyConditionExpression.push(`#key${i} ${filters[key].operator} :key${i}`)
           } else {
-            ExpressionAttributeNames[`#${key}`] = key
-            ExpressionAttributeValues[`:${key}`] = filters[key].value
-            FilterExpressions.push(`#${key} ${filters[key].operator} :${key}`)
+            ExpressionAttributeNames[`#key${i}`] = key
+            ExpressionAttributeValues[`:key${i}`] = filters[key].value
+            FilterExpressions.push(`#key${i} ${filters[key].operator} :key${i}`)
           }
+          // Increment the unique ID variable
+          i = i + 1
         }
 
         const params = pickBy({


### PR DESCRIPTION
…names.

Instead of expression attribute names being escaped as `#${key}`, they are now escaped as `#key${i}`, where `i` is unique for each attribute name.

This change converts requests to DynamoDB like this:
```javascript
ExpressionAttributeNames: {
  '#my.expression.name.with.reserved.words': 'foo',
  '#my.other.expression.name.with.reserved.words': 'bar'
}
```
to requests like this:
```javascript
ExpressionAttributeNames: {
  '#key1': 'foo',
  '#key2': 'bar'
}
```

preventing issues with invalid attribute names.