### PR TITLE
Add Host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ DYNAMO_ENDPOINT=http://localhost:8000 dynamodb-admin
 Options:
  - --open / -o - opens server URL in a default browser on start
  - --port PORT / -p PORT -  Port to run on (default: 8001)
+ - --host HOST / -h HOST -  Host to run on (default: localhost)
 
-You can also specify port to run on by setting environment variable `PORT` to given number. This will override value specified on the command line. This is legacy way to specify PORT.
+You can specify host & port to run on by setting environment variables `HOST` and `PORT` respectively. This will override value specified on the command line. This is legacy way to specify the HOST & PORT.
 
 If you use a local dynamodb that cares about credentials, you can configure them by using the following environment variables `AWS_REGION` `AWS_ACCESS_KEY_ID` `AWS_SECRET_ACCESS_KEY`
 
@@ -43,11 +44,12 @@ const dynClient = new AWS.DynamoDB.DocumentClient({service: dynamodb});
 
 const app = createServer(dynamodb, dynClient);
 
+const host = 'localhost';
 const port = 8001;
-const server = app.listen(port);
+const server = app.listen(port, host);
 server.on('listening', () => {
   const address = server.address();
-  console.log(`  listening on http://0.0.0.0:${address.port}`);
+  console.log(`  listening on http://${address.address}:${address.port}`);
 });
 ```
 

--- a/bin/dynamodb-admin.js
+++ b/bin/dynamodb-admin.js
@@ -26,6 +26,12 @@ parser.add_argument('-o', '--open', {
   help: 'Open server URL in default browser on start',
 })
 
+parser.add_argument('-H', '--host', {
+  type: 'str',
+  default: 'localhost',
+  help: 'Host to run on (default: localhost)',
+})
+
 parser.add_argument('-p', '--port', {
   type: 'int',
   default: 8001,
@@ -35,12 +41,13 @@ parser.add_argument('-p', '--port', {
 const args = parser.parse_args()
 
 const app = createServer()
+const host = process.env.HOST || args.host
 const port = process.env.PORT || args.port
-const server = app.listen(port)
+const server = app.listen(port, host)
 server.on('listening', () => {
   const address = server.address()
-  const url = `http://localhost:${address.port}`
-  console.log(`  dynamodb-admin listening on ${url} (alternatively http://0.0.0.0:${address.port})`)
+  const url = `http://${address.address}:${address.port}`
+  console.log(`  dynamodb-admin listening on ${url})`)
 
   if (args.open) {
     open(url)


### PR DESCRIPTION
# What's in this PR?
Addition of an host option alongside the existing port option to allow the server to bind to a specific network interface.

## Usage

Either pass `--host/-H` to `dynamodb-admin.js` or set the environment variable `HOST`.

## Notes for reviewers
- Backwards compatible
- Useful when dockerized and using multiple networks (amongst other situations) 