### PR TITLE
fix: make range (sort) key optional

### DIFF
--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -357,7 +357,7 @@
     }
 
     function addRangeKeyFilter (rangeKey, values) {
-      addFilter(rangeKey, values, true, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
+      addFilter(rangeKey, values, false, ['=', '<', '<=', '>', '>=', 'BETWEEN', 'begins_with'])
     }
 
     function removeFilter (node) {


### PR DESCRIPTION
Unfortunately it's impossible to search for an empty value in the sort key since the UI ignores filters with empty values. Not sure if that's something worth addressing but it would probably require re-thinking how the filters are presented in the UI.

But to be fair it worked like that also before this change as the UI required to put something in the sort key value.

Fixes #143