### PR TITLE
docs: Add note about access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ For example with the `amazon/dynamodb-local` docker image you can launch `dynamo
 AWS_REGION=eu-west-1 AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local dynamodb-admin
 ```
 
+If you are accessing your database from another piece of software, the `AWS_ACCESS_KEY_ID` used by that application must match the `AWS_ACCESS_KEY_ID` you used with `dynamodb-admin` if you want both to see the same data.
+
 ### Use as a library in your project
 
 ```js


### PR DESCRIPTION
Adding this short note to help others with [a problem I faced](https://github.com/aaronshaf/dynamodb-admin/issues/219) where I could not access my `dynamodb-admin` data from a Java app until I made sure the keys matched. Thanks for your time