### PR TITLE
fix: removing not necessary clear div on footer

### DIFF
--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,4 +1,3 @@
-<div class="myclear"></div>
 <footer class="footer">
   <span class="text-muted">Dark Theme</span>
   <% let checked = theme.toString() === "dark" ? "checked" : "" %>
@@ -6,11 +5,6 @@
 </footer>
 
 <style>
-  .myclear {
-    clear: both;
-    height: 60px;
-  }
-
   .footer {
     position: fixed;
     margin-top: 20px;


### PR DESCRIPTION
After the dark theme visualization was implemented, data visualization was covered by a blank div that blocked the scroll. This was only visible with small screen resolutions or by zoom

#### Visualization with problem
<img src=https://user-images.githubusercontent.com/13596701/157505117-faeae8e8-ed83-4cf6-b1e8-521bdd331543.png width="600" height="600"/>

#### Full visualization
<img src=https://user-images.githubusercontent.com/13596701/157505064-2ea8b0fb-8b8b-492c-993b-ab0cef7e3b2d.png width="600" height="600"/>

