### PR TITLE
Enhances the styling of the items table 

### DIFF
--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -60,7 +60,7 @@
 
     .items-table th:first-child, td:first-child {
       position: sticky;
-      left: 0px;
+      left: 0;
     }
 
     .items-table td:first-child {

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -58,7 +58,8 @@
       width: 100%;
     }
 
-    .items-table th:first-child, td:first-child {
+    .items-table th:first-child,
+    .items-table td:first-child {
       position: sticky;
       left: 0;
     }

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -57,6 +57,15 @@
       top: 0;
       width: 100%;
     }
+
+    .items-table th:first-child, td:first-child {
+      position: sticky;
+      left: 0px;
+    }
+
+    .items-table td:first-child {
+      background-color: white;
+    }
   </style>
 </head>
 <body class="container-fluid">
@@ -383,7 +392,7 @@
     }
 
     function renderItems(data) {
-      $('#actions-row').append(data.uniqueKeys.map(key => '<td>' + key + '</td>'))
+      $('#actions-row').append(data.uniqueKeys.map(key => '<th scope="col">' + key + '</th>'))
 
       if (data.Items.length) {
         $('#items-container').append(data.Items.map(item => {
@@ -497,11 +506,11 @@
 
     <div class="table-container d-none">
       <div class="scroll-indicator"></div>
-      <div class="table-wrapper">
-        <table class="table items-table">
-          <thead>
+      <div class="table-wrapper table-responsive">
+        <table class="table items-table table-hover">
+          <thead class="thead-light">
             <tr id="actions-row">
-              <td>Actions</td>
+              <th scope="col">Actions</th>
             </tr>
           </thead>
           <tbody id="items-container">


### PR DESCRIPTION
I've updated the styling of the table that lists all the items under a particular DynamoDB table page. 

- Updates the first row to be a `th` instead of `td` and its background is now light grey in color.
- Makes the table responsive by using an appropriate Bootstrap class.
- Makes the "Actions" column (first column) sticky so that users can easily click on the "View" link while scrolling horizontally through a large row item. 
- Every row has a style on hover that makes it easier to spot.

![Screenshot 2022-09-18 at 18-49-32 DynamoDB Admin](https://user-images.githubusercontent.com/15244609/190944684-662a56bd-acf2-4dd3-8fc9-8e2f18dc5595.png)
**Note:** The values in the above screenshot have been masked.

These styling changes make it easier to navigate rows with long string values. They improve the experience problems highlighted under https://github.com/aaronshaf/dynamodb-admin/issues/92.