### PR TITLE
fix: support comma character in key value

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -3,7 +3,7 @@ const path = require('path')
 const fs = require('fs')
 const os = require('os')
 const errorhandler = require('errorhandler')
-const { extractKey, extractKeysForItems, parseKey, doSearch } = require('./util')
+const { extractKey, extractKeysForItems, parseKey, doSearch, KEY_SEPARATOR } = require('./util')
 const { purgeTable } = require('./actions/purgeTable')
 const asyncMiddleware = require('./utils/asyncMiddleware')
 const bodyParser = require('body-parser')
@@ -109,6 +109,9 @@ exports.createServer = (dynamodb, docClient) => {
   app.set('json spaces', 2)
   app.set('view engine', 'ejs')
   app.set('views', path.resolve(__dirname, '..', 'views'))
+  app.locals = {
+    KEY_SEPARATOR,
+  }
 
   if (!dynamodb || !docClient) {
     const homeDir = getHomeDir()

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,3 +1,5 @@
+exports.KEY_SEPARATOR = ',016c2cec,'
+
 exports.extractKey = function(item, KeySchema) {
   return KeySchema.reduce((prev, current) => {
     return Object.assign({}, prev, {
@@ -7,7 +9,7 @@ exports.extractKey = function(item, KeySchema) {
 }
 
 exports.parseKey = function(keys, table) {
-  const splitKeys = keys.split(',')
+  const splitKeys = keys.split(exports.KEY_SEPARATOR)
 
   return table.KeySchema.reduce((prev, current, index) => {
     return Object.assign({}, prev, {

--- a/views/item.ejs
+++ b/views/item.ejs
@@ -51,7 +51,7 @@
         }).then((json) => {
           if (document.location.pathname.endsWith('/add-item')) {
             const urlPart1 = document.location.pathname.replace('/add-item', '')
-            const param = encodeURIComponent(Object.values(json).join(','))
+            const param = encodeURIComponent(Object.values(json).join('<%= KEY_SEPARATOR %>'))
 
             window.location = `${urlPart1}/items/${param}`
             return

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -405,7 +405,7 @@
 
       if (data.Items.length) {
         $('#items-container').append(data.Items.map(item => {
-          const viewUrl = '/tables/<%= Table.TableName %>/items/' + encodeURIComponent(Object.values(item.__key).join(','))
+          const viewUrl = '/tables/<%= Table.TableName %>/items/' + encodeURIComponent(Object.values(item.__key).join('<%= KEY_SEPARATOR %>'))
           const rowEl = $('<tr><td><a href="' + viewUrl + '">View</a></td></tr>')
 
           for (const column of data.uniqueKeys) {


### PR DESCRIPTION
Issue: When a document key includes comma characters (`,`), the `parseKey()` will return an incorrect value. Then all operations which work with `:key` path parameter will not work.

The improvement is using another separator, in this PR it is `,016c2cec,` - The first commit hash :-?
