### PR TITLE
fix: allow passing custom express instance to createServer

### DIFF
--- a/lib/backend.js
+++ b/lib/backend.js
@@ -104,8 +104,8 @@ function getHomeDir() {
   return null
 }
 
-exports.createServer = (dynamodb, docClient) => {
-  const app = express()
+exports.createServer = (dynamodb, docClient, expressInstance) => {
+  const app = expressInstance ? expressInstance : express()
   app.set('json spaces', 2)
   app.set('view engine', 'ejs')
   app.set('views', path.resolve(__dirname, '..', 'views'))

--- a/lib/backend.js
+++ b/lib/backend.js
@@ -104,8 +104,8 @@ function getHomeDir() {
   return null
 }
 
-exports.createServer = (dynamodb, docClient, expressInstance) => {
-  const app = expressInstance ? expressInstance : express()
+exports.createServer = (dynamodb, docClient, expressInstance = express()) => {
+  const app = expressInstance
   app.set('json spaces', 2)
   app.set('view engine', 'ejs')
   app.set('views', path.resolve(__dirname, '..', 'views'))


### PR DESCRIPTION
Added to createServer function a parameter to allow the inject of express instance to the library