### PR TITLE
fix: encode table name in the breadcrumb

### DIFF
--- a/views/item.ejs
+++ b/views/item.ejs
@@ -15,7 +15,7 @@
           text: 'Tables',
         },
         {
-          href: `/tables/${TableName}`,
+          href: `/tables/${encodeURIComponent(TableName)}`,
           text: Table.TableName,
           badge: Table.ItemCount,
         },


### PR DESCRIPTION
Fixes #424