### PR TITLE
feat: add base-path support for running behind reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY rollup.config.ts .
 COPY tsconfig.json .
 
 RUN npm ci
+RUN npm run build
 
 FROM node:20-alpine
 EXPOSE 8001

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Options:
  - `--port PORT` / `-p PORT` -  Port to run on (default: 8001)
  - `--host HOST` / `-h HOST` -  Host to run on (default: localhost)
  - `--dynamo-endpoint` - DynamoDB endpoint to connect to (default: http://localhost:8000).
+ - `--base-path` - Base path for the application (e.g., /dynamo). Useful when running behind a reverse proxy (default: empty).
  - `--skip-default-credentials` - Skip setting default credentials and region. By default the accessKeyId/secretAccessKey are set to "key" and "secret" and the region is set to "us-east-1". If you specify this argument then you need to ensure that credentials are provided some other way. See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html for more details on how default credentials provider works.
 
-Environment variables `HOST`, `PORT` and `DYNAMO_ENDPOINT` can also be used to set the respective options.
+Environment variables `HOST`, `PORT`, `BASE_PATH` and `DYNAMO_ENDPOINT` can also be used to set the respective options.
 
 If you use a local dynamodb that cares about credentials, you can configure them by using the following environment variables `AWS_REGION` `AWS_ACCESS_KEY_ID` `AWS_SECRET_ACCESS_KEY` or specify the `--skip-default-credentials` argument and rely on the default AWS SDK credentials resolving behavior.
 
@@ -32,6 +33,27 @@ AWS_REGION=eu-west-1 AWS_ACCESS_KEY_ID=local AWS_SECRET_ACCESS_KEY=local dynamod
 If you are accessing your database from another piece of software, the `AWS_ACCESS_KEY_ID` used by that application must match the `AWS_ACCESS_KEY_ID` you used with `dynamodb-admin` if you want both to see the same data.
 
 By default `dynamodb-admin` sets a default key/secret to values "key" and "secret" and the region to "us-east-1".
+
+### Running behind a reverse proxy
+
+When running behind a reverse proxy like nginx, you can use the `--base-path` option to specify a custom base path:
+
+```bash
+dynamodb-admin --base-path=/dynamo
+```
+
+Example nginx configuration:
+
+```nginx
+location /dynamo/ {
+    proxy_pass http://localhost:8001/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_cache_bypass $http_upgrade;
+}
+```
 
 ### Use as a library in your project
 

--- a/bin/dynamodb-admin.ts
+++ b/bin/dynamodb-admin.ts
@@ -48,9 +48,15 @@ parser.add_argument('--skip-default-credentials', {
     help: 'Skip setting default credentials and region. By default the accessKeyId/secretAccessKey are set to "key" and "secret" and the region is set to "us-east-1". If you specify this argument then you need to ensure that credentials are provided some other way. See https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html for more details on how default credentials provider works.',
 });
 
-const { host, port, open: openUrl, dynamo_endpoint: dynamoEndpoint, skip_default_credentials: skipDefaultCredentials } = parser.parse_args();
+parser.add_argument('--base-path', {
+    type: 'str',
+    default: process.env.BASE_PATH || '',
+    help: 'Base path for the application (e.g., /dynamo). Useful when running behind a reverse proxy.',
+});
 
-const app = createServer({ dynamoEndpoint, skipDefaultCredentials });
+const { host, port, open: openUrl, dynamo_endpoint: dynamoEndpoint, skip_default_credentials: skipDefaultCredentials, base_path: basePath } = parser.parse_args();
+
+const app = createServer({ dynamoEndpoint, skipDefaultCredentials, basePath });
 const server = app.listen(port, host);
 server.on('listening', () => {
     const address = server.address();

--- a/lib/backend.ts
+++ b/lib/backend.ts
@@ -10,10 +10,11 @@ export type CreateServerOptions = {
     expressInstance?: Express;
     dynamoEndpoint?: string;
     skipDefaultCredentials?: boolean;
+    basePath?: string;
 };
 
 export function createServer(options?: CreateServerOptions): Express {
-    const { dynamoDbClient, expressInstance, dynamoEndpoint, skipDefaultCredentials } = options || {};
+    const { dynamoDbClient, expressInstance, dynamoEndpoint, skipDefaultCredentials, basePath = '' } = options || {};
     const app = expressInstance || express();
     let dynamodb = dynamoDbClient;
 
@@ -27,7 +28,7 @@ export function createServer(options?: CreateServerOptions): Express {
 
     const ddbApi = new DynamoApiController(dynamodb);
 
-    setupRoutes(app, ddbApi);
+    setupRoutes(app, ddbApi, basePath);
 
     return app;
 }

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -14,32 +14,35 @@ import type { DynamoApiController } from './dynamoDbApi';
 
 const DEFAULT_THEME = process.env.DEFAULT_THEME || 'light';
 
-export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
-    app.use(errorhandler());
-    app.use('/assets', express.static(path.join(__dirname, '..', 'public')));
+export function setupRoutes(app: Express, ddbApi: DynamoApiController, basePath = ''): void {
+    const router = express.Router();
 
-    app.use(
+    router.use(errorhandler());
+    router.use('/assets', express.static(path.join(__dirname, '..', 'public')));
+
+    router.use(
         cookieParser(),
         (req, res, next) => {
             const { theme = DEFAULT_THEME } = req.cookies;
             res.locals = {
                 theme,
+                basePath,
             };
             next();
         },
     );
 
-    app.get('/', asyncMiddleware(async(_req, res) => {
+    router.get('/', asyncMiddleware(async(_req, res) => {
         const data = await listAllTables(ddbApi);
         res.render('tables', { data });
     }));
 
-    app.get('/api/tables', asyncMiddleware(async(_req, res) => {
+    router.get('/api/tables', asyncMiddleware(async(_req, res) => {
         const data = await listAllTables(ddbApi);
         res.send(data);
     }));
 
-    app.get('/create-table', (_req, res) => {
+    router.get('/create-table', (_req, res) => {
         res.render('create-table', {});
     });
 
@@ -58,7 +61,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         IndexType: 'global' | 'local';
     };
 
-    app.post(
+    router.post(
         '/create-table',
         bodyParser.json({ limit: '500kb' }),
         asyncMiddleware(async(req, res) => {
@@ -170,7 +173,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         }),
     );
 
-    app.delete('/tables', asyncMiddleware(async(_req, res) => {
+    router.delete('/tables', asyncMiddleware(async(_req, res) => {
         const tablesList = await listAllTables(ddbApi);
         if (tablesList.length === 0) {
             res.send('There are no tables to delete');
@@ -180,7 +183,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.send('Tables deleted');
     }));
 
-    app.delete('/tables-purge', asyncMiddleware(async(req, res) => {
+    router.delete('/tables-purge', asyncMiddleware(async(req, res) => {
         const tablesList = await listAllTables(ddbApi);
         if (tablesList.length === 0) {
             res.send('There are no tables to purge');
@@ -190,27 +193,27 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.send('Tables purged');
     }));
 
-    app.delete('/tables/:TableName', asyncMiddleware(async(req, res) => {
+    router.delete('/tables/:TableName', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         await ddbApi.deleteTable({ TableName });
         res.status(204).end();
     }));
 
-    app.delete('/tables/:TableName/all', asyncMiddleware(async(req, res) => {
+    router.delete('/tables/:TableName/all', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         await purgeTable(TableName, ddbApi);
         res.status(200).end();
     }));
 
-    app.get('/tables/:TableName/get', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName/get', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const hash = req.query.hash as string;
         const range = req.query.range as string;
         if (hash) {
             if (range) {
-                res.redirect(`/tables/${encodeURIComponent(TableName)}/items/${encodeURIComponent(hash)},${encodeURIComponent(range)}`);
+                res.redirect(`${basePath}/tables/${encodeURIComponent(TableName)}/items/${encodeURIComponent(hash)},${encodeURIComponent(range)}`);
             } else {
-                res.redirect(`/tables/${encodeURIComponent(TableName)}/items/${encodeURIComponent(hash)}`);
+                res.redirect(`${basePath}/tables/${encodeURIComponent(TableName)}/items/${encodeURIComponent(hash)}`);
             }
             return;
         }
@@ -225,7 +228,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         });
     }));
 
-    app.get('/tables/:TableName', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName', asyncMiddleware(async(req, res) => {
         const TableName = req.params.TableName;
         req.query = pickBy(req.query);
         const pageNum = typeof req.query.pageNum === 'string' ? Number.parseInt(req.query.pageNum) : 1;
@@ -252,7 +255,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.render('scan', data);
     }));
 
-    app.get('/tables/:TableName/items', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName/items', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         req.query = pickBy(req.query);
         const filters = typeof req.query.filters === 'string' ? JSON.parse(req.query.filters) : {};
@@ -352,7 +355,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.json(data);
     }));
 
-    app.get('/tables/:TableName/meta', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName/meta', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const [tableDescription, items] = await Promise.all([
             ddbApi.describeTable({ TableName }),
@@ -365,7 +368,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.render('meta', data);
     }));
 
-    app.delete('/tables/:TableName/items/:key', asyncMiddleware(async(req, res) => {
+    router.delete('/tables/:TableName/items/:key', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const tableDescription = await ddbApi.describeTable({ TableName });
         await ddbApi.deleteItem({
@@ -375,7 +378,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.status(204).end();
     }));
 
-    app.get('/tables/:TableName/add-item', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName/add-item', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const tableDescription = await ddbApi.describeTable({ TableName });
         const Item: Record<string, string | number> = {};
@@ -397,7 +400,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         });
     }));
 
-    app.get('/tables/:TableName/items/:key', asyncMiddleware(async(req, res) => {
+    router.get('/tables/:TableName/items/:key', asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const tableDescription = await ddbApi.describeTable({ TableName });
         const params = {
@@ -418,7 +421,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         });
     }));
 
-    app.put('/tables/:TableName/add-item', bodyParser.json({ limit: '500kb' }), asyncMiddleware(async(req, res) => {
+    router.put('/tables/:TableName/add-item', bodyParser.json({ limit: '500kb' }), asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const tableDescription = await ddbApi.describeTable({ TableName });
         await ddbApi.putItem({ TableName, Item: req.body });
@@ -432,7 +435,7 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         return;
     }));
 
-    app.put('/tables/:TableName/items/:key', bodyParser.json({ limit: '500kb' }), asyncMiddleware(async(req, res) => {
+    router.put('/tables/:TableName/items/:key', bodyParser.json({ limit: '500kb' }), asyncMiddleware(async(req, res) => {
         const { TableName } = req.params;
         const tableDescription = await ddbApi.describeTable({ TableName });
         await ddbApi.putItem({ TableName, Item: req.body });
@@ -443,8 +446,10 @@ export function setupRoutes(app: Express, ddbApi: DynamoApiController): void {
         res.json(response.Item);
     }));
 
-    app.use(((error, _req, res, _next) => {
+    router.use(((error, _req, res, _next) => {
         console.info(error.stack);
         res.status(500).json({ message: error.message });
     }) as ErrorRequestHandler);
+
+    app.use(basePath, router);
 }

--- a/views/create-table.ejs
+++ b/views/create-table.ejs
@@ -61,7 +61,7 @@
                     body: JSON.stringify(createTableRequest)
                 })
                 if (response.ok) {
-                    window.location = '/'
+                    window.location = '<%= basePath %>/'
                 } else {
                     const error = await response.text()
                     handleError(JSON.parse(error).message)

--- a/views/get.ejs
+++ b/views/get.ejs
@@ -10,7 +10,7 @@
     <%
       const breadcrumb = [
         {
-          href: '/',
+          href: basePath + '/',
           text: 'Tables',
         },
         {
@@ -24,17 +24,17 @@
 
     <ul class='nav nav-tabs'>
       <li class='nav-item'>
-        <a class='nav-link' href='/tables/<%= encodeURIComponent(Table.TableName) %>'>
+        <a class='nav-link' href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>'>
           Items
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link active" href="/tables/<%= encodeURIComponent(Table.TableName) %>/get">
+        <a class="nav-link active" href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/get'>
           Get
         </a>
       </li>
       <li class='nav-item'>
-        <a class='nav-link' href='/tables/<%= encodeURIComponent(Table.TableName) %>/meta'>Meta</a>
+        <a class='nav-link' href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/meta'>Meta</a>
       </li>
     </ul>
   </header>

--- a/views/item.ejs
+++ b/views/item.ejs
@@ -11,11 +11,11 @@
     <%
       const breadcrumb = [
         {
-          href: '/',
+          href: basePath + '/',
           text: 'Tables',
         },
         {
-          href: `/tables/${encodeURIComponent(TableName)}`,
+          href: `${basePath}/tables/${encodeURIComponent(TableName)}`,
           text: Table.TableName,
           badge: Table.ItemCount,
         },
@@ -94,7 +94,7 @@
           method: 'delete'
         }).then(async (response) => {
           if (response.ok) {
-            window.location = `/tables/<%= encodeURIComponent(TableName) %>`
+            window.location = '<%= basePath %>/tables/<%= encodeURIComponent(TableName) %>'
           } else {
             const responseText = await response.text()
             throw new Error(JSON.parse(responseText).message)

--- a/views/meta.ejs
+++ b/views/meta.ejs
@@ -11,7 +11,7 @@
     <%
       const breadcrumb = [
         {
-          href: '/',
+          href: basePath + '/',
           text: 'Tables',
         },
         {
@@ -25,17 +25,17 @@
 
     <ul class='nav nav-tabs'>
       <li class='nav-item'>
-        <a class='nav-link' href='/tables/<%= encodeURIComponent(Table.TableName) %>'>
+        <a class='nav-link' href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>'>
           Items
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="/tables/<%= encodeURIComponent(Table.TableName) %>/get">
+        <a class="nav-link" href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/get'>
           Get
         </a>
       </li>
       <li class='nav-item'>
-        <a class='nav-link active' href='/tables/<%= encodeURIComponent(Table.TableName) %>/meta'>Meta</a>
+        <a class='nav-link active' href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/meta'>Meta</a>
       </li>
     </ul>
 
@@ -59,14 +59,14 @@
           if (!confirm(`Are you sure you want to purge all records from table "<%= Table.TableName %>"?`)) {
             return
           }
-          fetch('/tables/<%= encodeURIComponent(Table.TableName) %>/all', {
+          fetch('<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/all', {
               method: 'delete'
           }).then(async (response) => {
               if (!response.ok) {
                   const responseText = await response.text()
                   throw new Error(JSON.parse(responseText).message)
               }
-              window.location.href = '/tables/<%= encodeURIComponent(Table.TableName) %>'
+              window.location.href = '<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>'
           }).catch((error) => {
               handleError(error.message)
           })
@@ -76,14 +76,14 @@
           if (!confirm(`Are you sure you want to delete table "<%= Table.TableName %>"?`)) {
             return
           }
-          fetch('/tables/<%= encodeURIComponent(Table.TableName) %>', {
+          fetch('<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>', {
               method: 'delete'
           }).then(async (response) => {
               if (!response.ok) {
                   const responseText = await response.text()
                   throw new Error(JSON.parse(responseText).message)
               }
-              window.location.href = '/'
+              window.location.href = '<%= basePath %>/'
           }).catch((error) => {
               handleError(error.message)
           })

--- a/views/partials/ace-deps.ejs
+++ b/views/partials/ace-deps.ejs
@@ -1,3 +1,3 @@
-<script src='/assets/vendor/ace/ace.js'></script>
-<script src='/assets/vendor/ace/mode-json.js'></script>
-<script src='/assets/vendor/ace/theme-monokai.js'></script>
+<script src='<%= basePath %>/assets/vendor/ace/ace.js'></script>
+<script src='<%= basePath %>/assets/vendor/ace/mode-json.js'></script>
+<script src='<%= basePath %>/assets/vendor/ace/theme-monokai.js'></script>

--- a/views/partials/bootstrap-deps.ejs
+++ b/views/partials/bootstrap-deps.ejs
@@ -1,8 +1,8 @@
-<script src='/assets/vendor/bootstrap/jquery-3.3.1.slim.min.js'></script>
-<script src='/assets/vendor/bootstrap/jquery.cookie.min.js'></script>
-<script src='/assets/vendor/bootstrap/bootstrap.bundle.min.js'></script>
-<script src="/assets/vendor/bootstrap-toggle/bootstrap4-toggle.min.js"></script>
-<link href="/assets/css/bootstrap4-toggle.min.css" rel="stylesheet">
+<script src='<%= basePath %>/assets/vendor/bootstrap/jquery-3.3.1.slim.min.js'></script>
+<script src='<%= basePath %>/assets/vendor/bootstrap/jquery.cookie.min.js'></script>
+<script src='<%= basePath %>/assets/vendor/bootstrap/bootstrap.bundle.min.js'></script>
+<script src="<%= basePath %>/assets/vendor/bootstrap-toggle/bootstrap4-toggle.min.js"></script>
+<link href="<%= basePath %>/assets/css/bootstrap4-toggle.min.css" rel="stylesheet">
 
 <script>
   $(function () {

--- a/views/partials/breadcrumb.ejs
+++ b/views/partials/breadcrumb.ejs
@@ -30,7 +30,7 @@
   }
 
   function setCookie(theme) {
-    $.cookie("theme", theme, { path: '/' });
+    $.cookie("theme", theme, { path: '<%= basePath %>/' });
   }
 
   function detectColorScheme() {

--- a/views/partials/head-tail.ejs
+++ b/views/partials/head-tail.ejs
@@ -1,3 +1,3 @@
 <% if(theme === "dark"){  %>
-<link rel='stylesheet' href='/assets/css/dark-theme.css'>
+<link rel='stylesheet' href='<%= basePath %>/assets/css/dark-theme.css'>
 <% } %>

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -2,7 +2,7 @@
 <title>DynamoDB Admin</title>
 <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>
 <meta http-equiv='x-ua-compatible' content='ie=edge'>
-<link rel='stylesheet' href='/assets/css/bootstrap.min.css'>
+<link rel='stylesheet' href='<%= basePath %>/assets/css/bootstrap.min.css'>
 
 <style>
 html, body {

--- a/views/scan.ejs
+++ b/views/scan.ejs
@@ -3,7 +3,7 @@
 <head>
   <%- include('partials/head') %>
   <%- include('partials/bootstrap-deps') %>
-  <script src='/assets/vendor/json-formatter/json-formatter.js'></script>
+  <script src='<%= basePath %>/assets/vendor/json-formatter/json-formatter.js'></script>
   <style>
     .table-container {
       margin-bottom: 1rem;
@@ -75,7 +75,7 @@
     <%
       const breadcrumb = [
         {
-          href: '/',
+          href: basePath + '/',
           text: 'Tables',
         },
         {
@@ -89,20 +89,20 @@
 
     <ul class="nav nav-tabs">
       <li class="nav-item">
-        <a class="nav-link active item-count" href="/tables/<%= encodeURIComponent(Table.TableName) %>">
+        <a class="nav-link active item-count" href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>'>
           Items
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="/tables/<%= encodeURIComponent(Table.TableName) %>/get">
+        <a class="nav-link" href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/get'>
           Get
         </a>
       </li>
       <li class="nav-item">
-        <a class="nav-link" href="/tables/<%= encodeURIComponent(Table.TableName) %>/meta">Meta</a>
+        <a class="nav-link" href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/meta'>Meta</a>
       </li>
       <li class="nav-item ml-auto">
-        <a href="/tables/<%= encodeURIComponent(Table.TableName) %>/add-item" class="nav-link">Create item</a>
+        <a href='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/add-item' class="nav-link">Create item</a>
       </li>
     </ul>
 
@@ -112,7 +112,7 @@
   <main>
     <form
       autocomplete="off"
-      action="/tables/<%= encodeURIComponent(Table.TableName) %>"
+      action='<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>'
       method="get"
       style="padding-top: 20px;padding-bottom: 20px;"
       id="form"
@@ -407,7 +407,7 @@
 
       if (data.Items.length) {
         $('#items-container').append(data.Items.map(item => {
-          const viewUrl = '/tables/<%= encodeURIComponent(Table.TableName) %>/items/' + encodeURIComponent(Object.values(item.__key).join(','))
+          const viewUrl = '<%= basePath %>/tables/<%= encodeURIComponent(Table.TableName) %>/items/' + encodeURIComponent(Object.values(item.__key).join(','))
           const rowEl = $('<tr><td><a href="' + viewUrl + '">View</a></td></tr>')
 
           for (const column of data.uniqueKeys) {

--- a/views/tables.ejs
+++ b/views/tables.ejs
@@ -13,7 +13,7 @@
       const breadcrumb = [
         {
           active: true,
-          href: '/',
+          href: basePath + '/',
           text: 'Tables',
         },
       ]
@@ -58,7 +58,7 @@
         return
       }
 
-      fetch(`/tables/${encodeURIComponent(TableName)}`, {
+      fetch(`<%= basePath %>/tables/${encodeURIComponent(TableName)}`, {
         method: 'delete'
       })
         .then(async (response) => {
@@ -78,7 +78,7 @@
         return
       }
 
-      fetch(`/tables/${encodeURIComponent(TableName)}/all`, {
+      fetch(`<%= basePath %>/tables/${encodeURIComponent(TableName)}/all`, {
         method: 'delete'
       }).then(async (response) => {
         if (!response.ok) {
@@ -95,7 +95,7 @@
         if (!confirm('Are you sure you want to purge all tables?')) {
           return
         }
-        fetch('/tables-purge', {
+        fetch('<%= basePath %>/tables-purge', {
           method: 'delete'
         }).then(async (response) => {
           const responseText = await response.text()
@@ -113,7 +113,7 @@
         if (!confirm('Are you sure you want to delete all tables?')) {
           return
         }
-        fetch('/tables', {
+        fetch('<%= basePath %>/tables', {
           method: 'delete'
         }).then(async (response) => {
           const responseText = await response.text()
@@ -136,14 +136,14 @@
     <ul class="list-group" id="table-list">
       <% for(var i = 0; i < data.length; i++) { %>
         <li class="list-group-item" data-table-name="<%= data[i].TableName %>">
-          <a href='/tables/<%= encodeURIComponent(data[i].TableName) %>'>
+          <a href='<%= basePath %>/tables/<%= encodeURIComponent(data[i].TableName) %>'>
             <%= data[i].TableName %>
           </a>
           <a href="#" onClick="deleteTable('<%= data[i].TableName %>'); return false"
               class="badge badge-danger badge-pill float-right ml-1">
             Delete
           </a>
-          <a href="/" onClick="purgeTable('<%= data[i].TableName %>'); return false"
+          <a href='#' onClick="purgeTable('<%= data[i].TableName %>'); return false"
              class="badge badge-warning badge-pill float-right ml-1">
             Purge
           </a>
@@ -154,7 +154,7 @@
       <% } %>
     </ul>
     <div style="margin-top: 12px; display: flex; justify-content: space-between;">
-      <a href='/create-table' class="btn btn-primary">
+      <a href='<%= basePath %>/create-table' class="btn btn-primary">
         Create table
       </a>
       <div>


### PR DESCRIPTION
Add --base-path CLI option and BASE_PATH env variable to allow deploying behind a reverse proxy (e.g., nginx). All routes use an Express Router mounted at the base path. All views updated to use basePath for links, assets, fetch URLs, and breadcrumb navigation. Fix mismatched quotes in EJS templates and add missing build step in Dockerfile.